### PR TITLE
各記事のリンク先をアプリ内ブラウザに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "expo-linking": "~7.0.5",
     "expo-router": "~4.0.17",
     "expo-status-bar": "~2.0.1",
+    "expo-web-browser": "~14.0.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.7",

--- a/src/components/PostItem.tsx
+++ b/src/components/PostItem.tsx
@@ -1,7 +1,8 @@
 import { COLORS } from '#/constants/environment'
 import { PostProps } from '#/types'
 import { useCallback } from 'react'
-import { Image, Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Image, Linking, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import * as WebBrowser from 'expo-web-browser'
 
 type Props = {
   post: PostProps
@@ -13,7 +14,14 @@ export const PostItem = ({ post }: Props) => {
   const hostname = new URL(content.url).hostname
 
   const onPress = useCallback(() => {
-    Linking.openURL(content.url)
+    if (Platform.OS === 'web') {
+      Linking.openURL(content.url)
+    } else {
+      const options: WebBrowser.WebBrowserOpenOptions = {
+        presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
+      }
+      WebBrowser.openBrowserAsync(content.url, options)
+    }
   }, [content])
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3802,6 +3802,11 @@ expo-status-bar@~2.0.1:
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-2.0.1.tgz#fc07726346dc30fbb68aadb0d7890b34fba42eee"
   integrity sha512-AkIPX7jWHRPp83UBZ1iXtVvyr0g+DgBVvIXTtlmPtmUsm8Vq9Bb5IGj86PW8osuFlgoTVAg7HI/+Ok7yEYwiRg==
 
+expo-web-browser@~14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/expo-web-browser/-/expo-web-browser-14.0.2.tgz#52d53947c42fdfb225e8c230418ffe508bcf98a7"
+  integrity sha512-Hncv2yojhTpHbP6SGWARBFdl7P6wBHc1O8IKaNsH0a/IEakq887o1eRhLxZ5IwztPQyRDhpqHdgJ+BjWolOnwA==
+
 expo@~52.0.31:
   version "52.0.31"
   resolved "https://registry.yarnpkg.com/expo/-/expo-52.0.31.tgz#ec6a5ac276d936ae1349c6127b6a6fff46c42aa4"


### PR DESCRIPTION
- expo-web-browser導入
- ただしWebをそのまま変更すると新規ウインドウで開いてしまい都合が悪いので、Webのみこれまで通り新規タブで開く形にする